### PR TITLE
Add typing-extensions dependency and enhance keyfilter and valfilter overloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
-    dependencies    = ["pytest-stubtester>=0.1.1"]
+    dependencies    = [
+    "pytest-stubtester>=0.1.1",
+    "typing-extensions>=4.10.0",
+]
     description     = "Type stubs for cytoolz"
     name            = "cytoolz-stubs"
     readme          = "README.md"

--- a/src/cytoolz-stubs/dicttoolz.pyi
+++ b/src/cytoolz-stubs/dicttoolz.pyi
@@ -18,7 +18,7 @@
 """
 
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
-from typing import Any, overload
+from typing import Any, TypeGuard, overload
 
 from typing_extensions import TypeIs
 
@@ -218,9 +218,15 @@ def itemmap[K, V, K1, V1](
 
 @overload
 def keyfilter[K, V, U](
+    predicate: Callable[[K], TypeGuard[U]],
+    d: Mapping[K, V],
+    factory: Callable[[], dict[U, V]] = ...,
+) -> dict[U, V]: ...
+@overload
+def keyfilter[K, V, U](
     predicate: Callable[[K], TypeIs[U]],
     d: Mapping[K, V],
-    factory: Callable[[], dict[K, V]] = ...,
+    factory: Callable[[], dict[U, V]] = ...,
 ) -> dict[U, V]: ...
 @overload
 def keyfilter[K, V](
@@ -229,9 +235,9 @@ def keyfilter[K, V](
     factory: Callable[[], dict[K, V]] = ...,
 ) -> dict[K, V]: ...
 def keyfilter[K, V, U](
-    predicate: Callable[[K], bool] | Callable[[K], TypeIs[U]],
+    predicate: Callable[[K], bool] | Callable[[K], TypeIs[U]] | Callable[[K], TypeGuard[U]],
     d: Mapping[K, V],
-    factory: Callable[[], dict[K, V]] = ...,
+    factory: Callable[[], dict[K, V]] | Callable[[], dict[U, V]] = ...,
 ) -> dict[K, V] | dict[U, V]:
     """Filter items in dictionary by key.
 
@@ -396,6 +402,12 @@ def update_in(
 
 @overload
 def valfilter[K, V, R](
+    predicate: Callable[[V], TypeGuard[R]],
+    d: Mapping[K, V],
+    factory: Callable[[], dict[K, R]] = ...,
+) -> dict[K, R]: ...
+@overload
+def valfilter[K, V, R](
     predicate: Callable[[V], TypeIs[R]],
     d: Mapping[K, V],
     factory: Callable[[], dict[K, R]] = ...,
@@ -406,11 +418,11 @@ def valfilter[K, V](
     d: Mapping[K, V],
     factory: Callable[[], dict[K, V]] = ...,
 ) -> dict[K, V]: ...
-def valfilter(
-    predicate: Callable[[Any], bool],
-    d: Mapping[Any, Any],
-    factory: Callable[[], dict[Any, Any]] = ...,
-) -> dict[Any, Any]:
+def valfilter[K, V, R](
+    predicate: Callable[[V], bool] | Callable[[V], TypeIs[R]] | Callable[[V], TypeGuard[R]],
+    d: Mapping[K, V],
+    factory: Callable[[], dict[K, V]] | Callable[[], dict[K, R]] = ...,
+) -> dict[K, V] | dict[K, R]:
     """Filter items in dictionary by value.
 
     >>> import cytoolz as cz

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "pytest-stubtester" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -148,7 +149,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pytest-stubtester", git = "https://github.com/OutSquareCapital/pytest-stubtester.git" }]
+requires-dist = [
+    { name = "pytest-stubtester", git = "https://github.com/OutSquareCapital/pytest-stubtester.git" },
+    { name = "typing-extensions", specifier = ">=4.10.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -301,4 +305,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]


### PR DESCRIPTION
Introduce the `typing-extensions` dependency to support new type hints. Update the overloads for `keyfilter` and `valfilter` functions to include additional type guard capabilities, improving type safety and flexibility.

I did not increment the version number.

Resolves #4.