### PR TITLE
Enhance type annotations and version update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
     name            = "cytoolz-stubs"
     readme          = "README.md"
     requires-python = ">=3.12"
-    version         = "0.3.4"
+    version         = "0.3.5"
 
 [build-system]
     build-backend = "uv_build"

--- a/src/cytoolz-stubs/curried/__init__.pyi
+++ b/src/cytoolz-stubs/curried/__init__.pyi
@@ -8,7 +8,7 @@ Example:
     >>> get(0, ("a", "b"))
     'a'
 
-    When we use it in higher order functions we o_ften want to pass a partially
+    When we use it in higher order functions we often want to pass a partially
     evaluated form
     >>> data = [(1, 2), (11, 22), (111, 222)]
     >>> list(map(lambda seq: get(0, seq), data))

--- a/src/cytoolz-stubs/dicttoolz.pyi
+++ b/src/cytoolz-stubs/dicttoolz.pyi
@@ -181,26 +181,29 @@ def itemfilter[K, V](
     """
 
 @overload
-def itemmap[K, V, K1, V1, F: MutableMapping[Any, Any]](
-    itemfunc: Callable[[tuple[K, V]], tuple[K1, V1]],
-    d: Mapping[K, V],
-    *,
-    factory: Callable[[], F],
-) -> F: ...
-@overload
 def itemmap[K, V, K1, V1](
-    itemfunc: Callable[[tuple[K, V]], tuple[K1, V1]],
+    func: Callable[[tuple[K, V]], tuple[K1, V1]],
     d: Mapping[K, V],
-) -> dict[K1, V1]: ...
-@overload
-def itemmap[K, V](func: type[reversed], d: dict[K, V]) -> dict[V, K]: ...
+    factory: Callable[[], MutableMapping[K1, V1]],
+) -> MutableMapping[K1, V1]: ...
 @overload
 def itemmap[K, V, K1, V1](
     func: Callable[[tuple[K, V]], tuple[K1, V1]],
-    d: dict[K, V],
+    d: Mapping[K, V],
 ) -> dict[K1, V1]: ...
+@overload
+def itemmap[K, V](
+    func: type[reversed[tuple[K, V]]],
+    d: Mapping[K, V],
+    factory: Callable[[], MutableMapping[V, K]],
+) -> MutableMapping[V, K]: ...
+@overload
+def itemmap[K, V](
+    func: type[reversed[tuple[K, V]]],
+    d: Mapping[K, V],
+) -> dict[V, K]: ...
 def itemmap[K, V, K1, V1](
-    func: Callable[[tuple[K, V]], tuple[K1, V1]] | type[reversed],
+    func: Callable[[tuple[K, V]], tuple[K1, V1]] | type[reversed[tuple[K, V]]],
     d: dict[K, V],
 ) -> dict[K1, V1] | dict[V, K]:
     """Apply function to items of dictionary.
@@ -257,14 +260,14 @@ def keyfilter[K, V, U](
 
 @overload
 def keymap[K, K1, V](
-    keyfunc: Callable[[K], K1],
+    func: Callable[[K], K1],
     d: Mapping[K, V],
     *,
     factory: Callable[[], MutableMapping[K1, V]] = ...,
 ) -> MutableMapping[K1, V]: ...
 @overload
 def keymap[K, K1, V](
-    keyfunc: Callable[[K], K1],
+    func: Callable[[K], K1],
     d: Mapping[K, V],
 ) -> dict[K1, V]: ...
 def keymap[K, V, K1](
@@ -441,34 +444,34 @@ def valfilter[K, V, R](
 
 @overload
 def valmap[K, V_inner, V_outer](
-    valfunc: type[dict[V_inner, V_outer]],
+    func: type[dict[V_inner, V_outer]],
     d: Mapping[K, Iterable[tuple[V_inner, V_outer]]],
 ) -> dict[K, dict[V_inner, V_outer]]: ...
 @overload
 def valmap[K, V_inner](
-    valfunc: type[list[V_inner]],
+    func: type[list[V_inner]],
     d: Mapping[K, Iterable[V_inner]],
 ) -> dict[K, list[V_inner]]: ...
 @overload
 def valmap[K, V_inner](
-    valfunc: type[tuple[V_inner, ...]],
+    func: type[tuple[V_inner, ...]],
     d: Mapping[K, Iterable[V_inner]],
 ) -> dict[K, tuple[V_inner, ...]]: ...
 @overload
 def valmap[K, V_inner](
-    valfunc: type[set[V_inner]],
+    func: type[set[V_inner]],
     d: Mapping[K, Iterable[V_inner]],
 ) -> dict[K, set[V_inner]]: ...
 @overload
 def valmap[K, V, V1](
-    valfunc: Callable[[V], V1],
+    func: Callable[[V], V1],
     d: Mapping[K, V],
     *,
     factory: Callable[[], MutableMapping[K, V1]],
 ) -> MutableMapping[K, V1]: ...
 @overload
 def valmap[K, V, V1](
-    valfunc: Callable[[V], V1],
+    func: Callable[[V], V1],
     d: Mapping[K, V],
 ) -> dict[K, V1]: ...
 def valmap[K, V, V1](

--- a/src/cytoolz-stubs/dicttoolz.pyi
+++ b/src/cytoolz-stubs/dicttoolz.pyi
@@ -193,17 +193,17 @@ def itemmap[K, V, K1, V1](
 ) -> dict[K1, V1]: ...
 @overload
 def itemmap[K, V](
-    func: type[reversed[tuple[K, V]]],
+    func: type[reversed],
     d: Mapping[K, V],
     factory: Callable[[], MutableMapping[V, K]],
 ) -> MutableMapping[V, K]: ...
 @overload
 def itemmap[K, V](
-    func: type[reversed[tuple[K, V]]],
+    func: type[reversed],
     d: Mapping[K, V],
 ) -> dict[V, K]: ...
 def itemmap[K, V, K1, V1](
-    func: Callable[[tuple[K, V]], tuple[K1, V1]] | type[reversed[tuple[K, V]]],
+    func: Callable[[tuple[K, V]], tuple[K1, V1]] | type[reversed],
     d: dict[K, V],
 ) -> dict[K1, V1] | dict[V, K]:
     """Apply function to items of dictionary.

--- a/src/cytoolz-stubs/functoolz.pyi
+++ b/src/cytoolz-stubs/functoolz.pyi
@@ -52,6 +52,78 @@ def complement[**P](func: Callable[P, bool]) -> Callable[P, bool]:
     False
     """
 
+@overload
+def compose[T]() -> Callable[[T], T]: ...
+@overload
+def compose[**P, T](func: Callable[P, T]) -> Callable[P, T]: ...
+@overload
+def compose[**P, T1, T2](
+    func_1: Callable[[T1], T2],
+    func_2: Callable[P, T1],
+) -> Callable[P, T2]: ...
+@overload
+def compose[**P, T1, T2, T3](
+    func_1: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[P, T1],
+) -> Callable[P, T3]: ...
+@overload
+def compose[**P, T1, T2, T3, T4](
+    func_1: Callable[[T3], T4],
+    func_2: Callable[[T2], T3],
+    func_3: Callable[[T1], T2],
+    func_4: Callable[P, T1],
+) -> Callable[P, T4]: ...
+@overload
+def compose[**P, T1, T2, T3, T4, T5](
+    func_1: Callable[[T4], T5],
+    func_2: Callable[[T3], T4],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T1], T2],
+    func_5: Callable[P, T1],
+) -> Callable[P, T5]: ...
+@overload
+def compose[**P, T1, T2, T3, T4, T5, T6](
+    func_1: Callable[[T5], T6],
+    func_2: Callable[[T4], T5],
+    func_3: Callable[[T3], T4],
+    func_4: Callable[[T2], T3],
+    func_5: Callable[[T1], T2],
+    func_6: Callable[P, T1],
+) -> Callable[P, T6]: ...
+@overload
+def compose[**P, T1, T2, T3, T4, T5, T6, T7](
+    func_1: Callable[[T6], T7],
+    func_2: Callable[[T5], T6],
+    func_3: Callable[[T4], T5],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T2], T3],
+    func_6: Callable[[T1], T2],
+    func_7: Callable[P, T1],
+) -> Callable[P, T7]: ...
+@overload
+def compose[**P, T1, T2, T3, T4, T5, T6, T7, T8](
+    func_1: Callable[[T7], T8],
+    func_2: Callable[[T6], T7],
+    func_3: Callable[[T5], T6],
+    func_4: Callable[[T4], T5],
+    func_5: Callable[[T3], T4],
+    func_6: Callable[[T2], T3],
+    func_7: Callable[[T1], T2],
+    func_8: Callable[P, T1],
+) -> Callable[P, T8]: ...
+@overload
+def compose[**P, T1, T2, T3, T4, T5, T6, T7, T8, T9](
+    func_1: Callable[[T8], T9],
+    func_2: Callable[[T7], T8],
+    func_3: Callable[[T6], T7],
+    func_4: Callable[[T5], T6],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T3], T4],
+    func_7: Callable[[T2], T3],
+    func_8: Callable[[T1], T2],
+    func_9: Callable[P, T1],
+) -> Callable[P, T9]: ...
 def compose(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """Compose functions to operate in series.
 
@@ -75,33 +147,77 @@ def compose(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """
 
 @overload
-def compose_left[**P, T](fn_1: Callable[P, T]) -> Callable[P, T]: ...
+def compose_left[T]() -> Callable[[T], T]: ...
 @overload
-def compose_left[**P, T, T1](
-    fn_1: Callable[P, T],
-    fn_2: Callable[[T], T1],
-) -> Callable[P, T1]: ...
+def compose_left[**P, T](func: Callable[P, T]) -> Callable[P, T]: ...
 @overload
-def compose_left[**P, T, T1, T2](
-    fn_1: Callable[P, T],
-    fn_2: Callable[[T], T1],
-    fn_3: Callable[[T1], T2],
+def compose_left[**P, T1, T2](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
 ) -> Callable[P, T2]: ...
 @overload
-def compose_left[**P, T, T1, T2, T3](
-    fn_1: Callable[P, T],
-    fn_2: Callable[[T], T1],
-    fn_3: Callable[[T1], T2],
-    fn_4: Callable[[T2], T3],
+def compose_left[**P, T1, T2, T3](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
 ) -> Callable[P, T3]: ...
 @overload
-def compose_left[**P, T, T1, T2, T3, T4](
-    fn_1: Callable[P, T],
-    fn_2: Callable[[T], T1],
-    fn_3: Callable[[T1], T2],
-    fn_4: Callable[[T2], T3],
-    fn_5: Callable[[T3], T4],
+def compose_left[**P, T1, T2, T3, T4](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
 ) -> Callable[P, T4]: ...
+@overload
+def compose_left[**P, T1, T2, T3, T4, T5](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+) -> Callable[P, T5]: ...
+@overload
+def compose_left[**P, T1, T2, T3, T4, T5, T6](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+) -> Callable[P, T6]: ...
+@overload
+def compose_left[**P, T1, T2, T3, T4, T5, T6, T7](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+) -> Callable[P, T7]: ...
+@overload
+def compose_left[**P, T1, T2, T3, T4, T5, T6, T7, T8](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+    func_8: Callable[[T7], T8],
+) -> Callable[P, T8]: ...
+@overload
+def compose_left[**P, T1, T2, T3, T4, T5, T6, T7, T8, T9](
+    func_1: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+    func_8: Callable[[T7], T8],
+    func_9: Callable[[T8], T9],
+) -> Callable[P, T9]: ...
 def compose_left(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """Compose functions to operate in series.
 
@@ -124,7 +240,7 @@ def compose_left(*funcs: Callable[..., Any]) -> Callable[..., Any]:
 
     """
 
-class curry:  # noqa: N801
+class curry[**P, T]:  # noqa: N801
     """Curry a callable function.
 
     Enables partial application of arguments through calling a function with an
@@ -155,8 +271,19 @@ class curry:  # noqa: N801
 
     """
 
-    def __init__(self, *args: object, **kwargs: object) -> None: ...
-    def __call__(self, *args: object, **kwargs: object) -> object: ...
+    @property
+    def func(self) -> Callable[P, T]: ...
+    @property
+    def args(self) -> tuple[Any, ...]: ...
+    @property
+    def keywords(self) -> dict[str, Any]: ...
+    def __init__(self, func: Callable[P, T], /, *args: object, **kwargs: object) -> None: ...
+    @overload
+    def __call__(self, /, *args: P.args, **kwargs: P.kwargs) -> T: ...
+    @overload
+    def __call__(self, /, *args: object, **kwargs: object) -> Callable[..., T]: ...
+    def bind(self, /, *args: object, **kwargs: object) -> Callable[..., T]: ...
+    def call(self, /, *args: P.args, **kwargs: P.kwargs) -> T: ...
 
 def do[T](func: Callable[[T], Any], x: T) -> T:
     """Runs ``func`` on ``x``, returns ``x``.
@@ -319,33 +446,85 @@ def memoize[T](
     """
 
 @overload
-def pipe[**P, T](data: T, fn1: Callable[P, T]) -> T: ...
+def pipe[T](data: T) -> T: ...
 @overload
-def pipe[**P, T, T1](data: T, fn1: Callable[P, T], fn2: Callable[[T], T1]) -> T1: ...
+def pipe[T, T1](data: T, func: Callable[[T], T1]) -> T1: ...
 @overload
-def pipe[**P, T, T1, T2](
+def pipe[T, T1, T2](
     data: T,
-    fn1: Callable[P, T],
-    fn2: Callable[[T], T1],
-    fn3: Callable[[T1], T2],
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
 ) -> T2: ...
 @overload
-def pipe[**P, T, T1, T2, T3](
+def pipe[T, T1, T2, T3](
     data: T,
-    fn1: Callable[P, T],
-    fn2: Callable[[T], T1],
-    fn3: Callable[[T1], T2],
-    fn4: Callable[[T2], T3],
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
 ) -> T3: ...
 @overload
-def pipe[**P, T, T1, T2, T3, T4](
+def pipe[T, T1, T2, T3, T4](
     data: T,
-    fn1: Callable[P, T],
-    fn2: Callable[[T], T1],
-    fn3: Callable[[T1], T2],
-    fn4: Callable[[T2], T3],
-    fn5: Callable[[T3], T4],
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
 ) -> T4: ...
+@overload
+def pipe[T, T1, T2, T3, T4, T5](
+    data: T,
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+) -> T5: ...
+@overload
+def pipe[T, T1, T2, T3, T4, T5, T6](
+    data: T,
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+) -> T6: ...
+@overload
+def pipe[T, T1, T2, T3, T4, T5, T6, T7](
+    data: T,
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+) -> T7: ...
+@overload
+def pipe[T, T1, T2, T3, T4, T5, T6, T7, T8](
+    data: T,
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+    func_8: Callable[[T7], T8],
+) -> T8: ...
+@overload
+def pipe[T, T1, T2, T3, T4, T5, T6, T7, T8, T9](
+    data: T,
+    func_1: Callable[[T], T1],
+    func_2: Callable[[T1], T2],
+    func_3: Callable[[T2], T3],
+    func_4: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_6: Callable[[T5], T6],
+    func_7: Callable[[T6], T7],
+    func_8: Callable[[T7], T8],
+    func_9: Callable[[T8], T9],
+) -> T9: ...
 def pipe(data: Any, *funcs: Callable[..., Any]) -> Any:
     """Pipe a value through a sequence of functions.
 

--- a/src/cytoolz-stubs/functoolz.pyi
+++ b/src/cytoolz-stubs/functoolz.pyi
@@ -58,71 +58,71 @@ def compose[T]() -> Callable[[T], T]: ...
 def compose[**P, T](func: Callable[P, T]) -> Callable[P, T]: ...
 @overload
 def compose[**P, T1, T2](
-    func_1: Callable[[T1], T2],
-    func_2: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T2]: ...
 @overload
 def compose[**P, T1, T2, T3](
-    func_1: Callable[[T2], T3],
+    func_3: Callable[[T2], T3],
     func_2: Callable[[T1], T2],
-    func_3: Callable[P, T1],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T3]: ...
 @overload
 def compose[**P, T1, T2, T3, T4](
-    func_1: Callable[[T3], T4],
-    func_2: Callable[[T2], T3],
-    func_3: Callable[[T1], T2],
-    func_4: Callable[P, T1],
+    func_4: Callable[[T3], T4],
+    func_3: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T4]: ...
 @overload
 def compose[**P, T1, T2, T3, T4, T5](
-    func_1: Callable[[T4], T5],
-    func_2: Callable[[T3], T4],
+    func_5: Callable[[T4], T5],
+    func_4: Callable[[T3], T4],
     func_3: Callable[[T2], T3],
-    func_4: Callable[[T1], T2],
-    func_5: Callable[P, T1],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T5]: ...
 @overload
 def compose[**P, T1, T2, T3, T4, T5, T6](
-    func_1: Callable[[T5], T6],
-    func_2: Callable[[T4], T5],
-    func_3: Callable[[T3], T4],
-    func_4: Callable[[T2], T3],
-    func_5: Callable[[T1], T2],
-    func_6: Callable[P, T1],
+    func_6: Callable[[T5], T6],
+    func_5: Callable[[T4], T5],
+    func_4: Callable[[T3], T4],
+    func_3: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T6]: ...
 @overload
 def compose[**P, T1, T2, T3, T4, T5, T6, T7](
-    func_1: Callable[[T6], T7],
-    func_2: Callable[[T5], T6],
-    func_3: Callable[[T4], T5],
+    func_7: Callable[[T6], T7],
+    func_6: Callable[[T5], T6],
+    func_5: Callable[[T4], T5],
     func_4: Callable[[T3], T4],
-    func_5: Callable[[T2], T3],
-    func_6: Callable[[T1], T2],
-    func_7: Callable[P, T1],
+    func_3: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T7]: ...
 @overload
 def compose[**P, T1, T2, T3, T4, T5, T6, T7, T8](
-    func_1: Callable[[T7], T8],
-    func_2: Callable[[T6], T7],
-    func_3: Callable[[T5], T6],
-    func_4: Callable[[T4], T5],
-    func_5: Callable[[T3], T4],
-    func_6: Callable[[T2], T3],
-    func_7: Callable[[T1], T2],
-    func_8: Callable[P, T1],
+    func_8: Callable[[T7], T8],
+    func_7: Callable[[T6], T7],
+    func_6: Callable[[T5], T6],
+    func_5: Callable[[T4], T5],
+    func_4: Callable[[T3], T4],
+    func_3: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T8]: ...
 @overload
 def compose[**P, T1, T2, T3, T4, T5, T6, T7, T8, T9](
-    func_1: Callable[[T8], T9],
-    func_2: Callable[[T7], T8],
-    func_3: Callable[[T6], T7],
-    func_4: Callable[[T5], T6],
+    func_9: Callable[[T8], T9],
+    func_8: Callable[[T7], T8],
+    func_7: Callable[[T6], T7],
+    func_6: Callable[[T5], T6],
     func_5: Callable[[T4], T5],
-    func_6: Callable[[T3], T4],
-    func_7: Callable[[T2], T3],
-    func_8: Callable[[T1], T2],
-    func_9: Callable[P, T1],
+    func_4: Callable[[T3], T4],
+    func_3: Callable[[T2], T3],
+    func_2: Callable[[T1], T2],
+    func_1: Callable[P, T1],
 ) -> Callable[P, T9]: ...
 def compose(*funcs: Callable[..., Any]) -> Callable[..., Any]:
     """Compose functions to operate in series.

--- a/src/cytoolz-stubs/itertoolz.pyi
+++ b/src/cytoolz-stubs/itertoolz.pyi
@@ -41,7 +41,7 @@ def accumulate[T](
 
     """
 
-def concat[T](seqs: Iterable[Iterable[T]] | Iterable[T]) -> Iterator[T]:
+def concat[T](seqs: Iterable[Iterable[T]]) -> Iterator[T]:
     """Concatenate zero or more iterables, any of which may be infinite.
 
     An infinite sequence will prevent the rest of the arguments from
@@ -70,7 +70,7 @@ def concatv[T](*seqs: Iterable[T]) -> Iterator[T]:
 
     """
 
-def cons[T](el: T, seq: Iterable[T]) -> Iterator[T]:
+def cons[T, U](el: T, seq: Iterable[U]) -> Iterator[T | U]:
     """Add el to beginning of (possibly infinite) sequence seq.
 
     >>> import cytoolz as cz
@@ -785,7 +785,7 @@ def sliding_window(n: int, seq: Iterable[Any]) -> Iterator[tuple[Any, ...]]:
 def tail[S: Sequence[Any]](n: int, seq: S) -> S: ...
 @overload
 def tail[T](n: int, seq: Iterable[T]) -> tuple[T, ...]: ...
-def tail[T](n: int, seq: Iterable[T]) -> Sequence[Any] | tuple[Any, ...]:
+def tail[T](n: int, seq: Iterable[T]) -> Sequence[T] | tuple[T, ...]:
     """The last n elements of a sequence.
 
     Args:

--- a/src/cytoolz-stubs/itertoolz.pyi
+++ b/src/cytoolz-stubs/itertoolz.pyi
@@ -1,12 +1,5 @@
-from collections.abc import (
-    Callable,
-    Collection,
-    Iterable,
-    Iterator,
-    Mapping,
-    Sequence,
-)
-from typing import Any, Literal, overload
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
+from typing import Any, Literal, TypeGuard, overload
 
 from typing_extensions import TypeIs
 
@@ -303,7 +296,13 @@ def isdistinct(seq: Collection[Any]) -> bool:
     """
 
 @overload
-def isiterable[T: Iterable[Any]](x: T) -> TypeIs[T]: ...
+def isiterable[T](x: Iterable[T]) -> TypeGuard[Iterable[T]]: ...
+@overload
+def isiterable[T](x: Iterable[T]) -> TypeIs[Iterable[T]]: ...
+@overload
+def isiterable(x: object) -> TypeGuard[Iterable[Any]]: ...
+@overload
+def isiterable(x: object) -> TypeIs[Iterable[Any]]: ...
 @overload
 def isiterable(x: object) -> bool: ...
 def isiterable(x: Any) -> bool:

--- a/src/cytoolz-stubs/itertoolz.pyi
+++ b/src/cytoolz-stubs/itertoolz.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Literal, TypeGuard, overload
+from typing import Any, Literal, overload
 
 from typing_extensions import TypeIs
 
@@ -41,7 +41,7 @@ def accumulate[T](
 
     """
 
-def concat[T](seqs: Iterable[Iterable[T]]) -> Iterator[T]:
+def concat[T](seqs: Iterable[Iterable[T]] | Iterable[T]) -> Iterator[T]:
     """Concatenate zero or more iterables, any of which may be infinite.
 
     An infinite sequence will prevent the rest of the arguments from
@@ -70,7 +70,7 @@ def concatv[T](*seqs: Iterable[T]) -> Iterator[T]:
 
     """
 
-def cons[T, U](el: T, seq: Iterable[U]) -> Iterator[T | U]:
+def cons[T](el: T, seq: Iterable[T]) -> Iterator[T]:
     """Add el to beginning of (possibly infinite) sequence seq.
 
     >>> import cytoolz as cz
@@ -295,17 +295,7 @@ def isdistinct(seq: Collection[Any]) -> bool:
     True
     """
 
-@overload
-def isiterable[T](x: Iterable[T]) -> TypeGuard[Iterable[T]]: ...
-@overload
-def isiterable[T](x: Iterable[T]) -> TypeIs[Iterable[T]]: ...
-@overload
-def isiterable(x: object) -> TypeGuard[Iterable[Any]]: ...
-@overload
-def isiterable(x: object) -> TypeIs[Iterable[Any]]: ...
-@overload
-def isiterable(x: object) -> bool: ...
-def isiterable(x: Any) -> bool:
+def isiterable(x: object) -> TypeIs[Iterable[Any]]:
     """Is x iterable?
 
     >>> import cytoolz as cz

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ wheels = [
 
 [[package]]
 name = "cytoolz-stubs"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "pytest-stubtester" },


### PR DESCRIPTION
Improve type annotations for various functions, add TypeGuard for isiterable, and fix parameter names in itemmap and valmap. Increment version to 3.5.

compose: 9 overloads is the same cost as 5 overloads. 

curry: based on typeshed functools.partial

I couldn't get stubtester or pytest-stubtester to work.

Copilot Code Review
The curry class now has type parameters [**P, T] and includes new methods (bind, call) and properties (func, args, keywords). This is a significant API expansion that should be verified to match the actual runtime behavior of cytoolz.functoolz.curry.